### PR TITLE
Update instructions to only publish package configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Laravel DigitalOcean requires connection configuration.
 To get started, you'll need to publish all vendor assets:
 
 ```bash
-$ php artisan vendor:publish
+$ php artisan vendor:publish --provider="GrahamCampbell\DigitalOcean\DigitalOceanServiceProvider"
 ```
 
 This will create a `config/digitalocean.php` file in your app that you can modify to set your configuration. Also, make sure you check for changes to the original config file in this package between releases.


### PR DESCRIPTION
When calling `php artisan vendor:publish`  the provider name should be appended as to avoid publish other packages files.