### PR TITLE
Bumped Laravel maximum version to 5.7.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,11 @@ matrix:
         - LARAVEL_VERSION=5.6.*
         - SYMFONY_VERSION=^4.0
         - PHPUNIT_VERSION=^7.0
+    - php: 7.1
+      env:
+        - LARAVEL_VERSION=5.7.*
+        - SYMFONY_VERSION=^4.0
+        - PHPUNIT_VERSION=^7.0
     - php: 7.2
       env:
         - LARAVEL_VERSION=5.5.*
@@ -22,6 +27,11 @@ matrix:
     - php: 7.2
       env:
         - LARAVEL_VERSION=5.6.*
+        - SYMFONY_VERSION=^4.0
+        - PHPUNIT_VERSION=^7.0
+    - php: 7.2
+      env:
+        - LARAVEL_VERSION=5.7.*
         - SYMFONY_VERSION=^4.0
         - PHPUNIT_VERSION=^7.0
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^7.1.3",
         "illuminate/contracts": "5.5.*|5.6.*|5.7.*",
         "illuminate/support": "5.5.*|5.6.*|5.7.*",
-        "graham-campbell/manager": "^4.0",
+        "graham-campbell/manager": "^4.1",
         "toin0u/digitalocean-v2": "^2.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/contracts": "5.5.*|5.6.*",
-        "illuminate/support": "5.5.*|5.6.*",
+        "illuminate/contracts": "5.5.*|5.6.*|5.7.*",
+        "illuminate/support": "5.5.*|5.6.*|5.7.*",
         "graham-campbell/manager": "^4.0",
         "toin0u/digitalocean-v2": "^2.0"
     },


### PR DESCRIPTION
I bumped the version to Laravel 5.7.x after reading through the upgrade guide to verify that your software is compatible with it. Please merge this in and tag it with a new version to allow for our production system to pull the code.